### PR TITLE
Update for Rails 7 compatibility (and some readme love)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MentionSystem
 
-[![Build Status](https://travis-ci.org/pmviva/mention_system.png?branch=master)](https://travis-ci.org/pmviva/mention_system)
+[![Build Status](https://github.com/pmviva/mention_system/actions/workflows/ci.yml/badge.svg)](https://github.com/pmviva/mention_system/actions)
 [![Gem Version](https://badge.fury.io/rb/mention_system.svg)](http://badge.fury.io/rb/mention_system)
 [![Code Climate](https://codeclimate.com/github/pmviva/mention_system/badges/gpa.svg)](https://codeclimate.com/github/pmviva/mention_system)
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 An active record mention system developed using ruby on rails applying domain driven design and test driven development principles.
 
-For rails 4 support use branch v0.0.7-stable.
+* For rails 4 support use branch v0.0.7-stable.
+* For rails 5 support use branch v0.1.1-stable.
+* For rails 6+ support use the latest version.
 
-For rails 5 support use branch v0.1.1-stable.
-
-This gem is heavily influenced by cmer/socialization.
+This gem is heavily influenced by [cmer/socialization.](https://github.com/cmer/socialization)
 
 ## Installation
 

--- a/mention_system.gemspec
+++ b/mention_system.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = Gem::Requirement.new(">= 2.5.5")
 
-  spec.add_dependency "rails", [ "~> 6.0" ]
+  spec.add_dependency "rails", [ ">= 6.0" ]
 
   spec.add_development_dependency "appraisal", "~> 2.2"
   spec.add_development_dependency "bundler", "~> 2.1"


### PR DESCRIPTION
Hi there @BilalBudhani,

I wasn't able to install this gem in my Rails 7.0 app, because the gemspec still required Rails `~> 6.0` which basically locks the version of Rails it will accept to 6.0 -> 6.xx and no higher. I've fixed that and it's working.

I've also given the README some love.

Please let me know if you need anything else from me in terms of this PR.